### PR TITLE
Use latest version of ob libs and release version 1.1.73

### DIFF
--- a/forgerock-openbanking-jwkms-core/pom.xml
+++ b/forgerock-openbanking-jwkms-core/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.jwkms</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-        <version>1.1.73-SNAPSHOT</version>
+        <version>1.1.73</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-core/pom.xml
+++ b/forgerock-openbanking-jwkms-core/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.jwkms</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-        <version>1.1.73</version>
+        <version>1.1.73-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-core/pom.xml
+++ b/forgerock-openbanking-jwkms-core/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.jwkms</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-        <version>1.1.73</version>
+        <version>1.1.74-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-embedded/pom.xml
+++ b/forgerock-openbanking-jwkms-embedded/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.jwkms</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-        <version>1.1.73-SNAPSHOT</version>
+        <version>1.1.73</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-embedded/pom.xml
+++ b/forgerock-openbanking-jwkms-embedded/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.jwkms</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-        <version>1.1.73</version>
+        <version>1.1.73-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-embedded/pom.xml
+++ b/forgerock-openbanking-jwkms-embedded/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.jwkms</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-        <version>1.1.73</version>
+        <version>1.1.74-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-sample/pom.xml
+++ b/forgerock-openbanking-jwkms-sample/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.jwkms</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-        <version>1.1.73-SNAPSHOT</version>
+        <version>1.1.73</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-sample/pom.xml
+++ b/forgerock-openbanking-jwkms-sample/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.jwkms</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-        <version>1.1.73</version>
+        <version>1.1.73-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-sample/pom.xml
+++ b/forgerock-openbanking-jwkms-sample/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.jwkms</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-        <version>1.1.73</version>
+        <version>1.1.74-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-server/pom.xml
+++ b/forgerock-openbanking-jwkms-server/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.jwkms</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-        <version>1.1.73-SNAPSHOT</version>
+        <version>1.1.73</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-server/pom.xml
+++ b/forgerock-openbanking-jwkms-server/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.jwkms</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-        <version>1.1.73</version>
+        <version>1.1.73-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-server/pom.xml
+++ b/forgerock-openbanking-jwkms-server/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.jwkms</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-        <version>1.1.73</version>
+        <version>1.1.74-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - JWKMS</name>
     <groupId>com.forgerock.openbanking.jwkms</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-    <version>1.1.73-SNAPSHOT</version>
+    <version>1.1.73</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -117,7 +117,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-jwkms.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-jwkms.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-jwkms.git</url>
-      <tag>HEAD</tag>
+      <tag>1.1.73</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-parent</artifactId>
-        <version>1.0.81</version>
+        <version>1.0.82</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 
@@ -44,8 +44,8 @@
     <url>http://www.forgerock.org</url>
 
     <properties>
-        <ob-common.version>1.0.79</ob-common.version>
-        <ob-clients.version>1.0.38</ob-clients.version>
+        <ob-common.version>1.0.81</ob-common.version>
+        <ob-clients.version>1.0.40</ob-clients.version>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - JWKMS</name>
     <groupId>com.forgerock.openbanking.jwkms</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-    <version>1.1.73</version>
+    <version>1.1.74-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -117,7 +117,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-jwkms.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-jwkms.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-jwkms.git</url>
-      <tag>1.1.73</tag>
+      <tag>HEAD</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - JWKMS</name>
     <groupId>com.forgerock.openbanking.jwkms</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-    <version>1.1.73</version>
+    <version>1.1.73-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -117,7 +117,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-jwkms.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-jwkms.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-jwkms.git</url>
-      <tag>1.1.73</tag>
+      <tag>HEAD</tag>
   </scm>
 
   <distributionManagement>


### PR DESCRIPTION
openbanking-parent	1.0.82
ob-commons.version 	1.0.81
ob-clients.version	        1.0.40
ob-auth.version		1.0.62

These versions use the nimbusds shaded versions of minidev classes
such as JSONObject