### PR TITLE
Create release 1.2.6

### DIFF
--- a/forgerock-openbanking-jwkms-core/pom.xml
+++ b/forgerock-openbanking-jwkms-core/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.jwkms</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-        <version>1.2.6-SNAPSHOT</version>
+        <version>1.2.6</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-core/pom.xml
+++ b/forgerock-openbanking-jwkms-core/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.jwkms</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-        <version>1.2.6</version>
+        <version>1.2.7-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-embedded/pom.xml
+++ b/forgerock-openbanking-jwkms-embedded/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.jwkms</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-        <version>1.2.6-SNAPSHOT</version>
+        <version>1.2.6</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-embedded/pom.xml
+++ b/forgerock-openbanking-jwkms-embedded/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.jwkms</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-        <version>1.2.6</version>
+        <version>1.2.7-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-sample/pom.xml
+++ b/forgerock-openbanking-jwkms-sample/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.jwkms</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-        <version>1.2.6-SNAPSHOT</version>
+        <version>1.2.6</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-sample/pom.xml
+++ b/forgerock-openbanking-jwkms-sample/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.jwkms</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-        <version>1.2.6</version>
+        <version>1.2.7-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-server/pom.xml
+++ b/forgerock-openbanking-jwkms-server/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.jwkms</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-        <version>1.2.6-SNAPSHOT</version>
+        <version>1.2.6</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-server/pom.xml
+++ b/forgerock-openbanking-jwkms-server/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.jwkms</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-        <version>1.2.6</version>
+        <version>1.2.7-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - JWKMS</name>
     <groupId>com.forgerock.openbanking.jwkms</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-    <version>1.2.6</version>
+    <version>1.2.7-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -117,7 +117,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-jwkms.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-jwkms.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-jwkms.git</url>
-      <tag>1.2.6</tag>
+      <tag>HEAD</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - JWKMS</name>
     <groupId>com.forgerock.openbanking.jwkms</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-    <version>1.2.6-SNAPSHOT</version>
+    <version>1.2.6</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -117,7 +117,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-jwkms.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-jwkms.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-jwkms.git</url>
-      <tag>HEAD</tag>
+      <tag>1.2.6</tag>
   </scm>
 
   <distributionManagement>


### PR DESCRIPTION
Use v 1.2.7 of openbanking commons 
https://github.com/OpenBankingToolkit/openbanking-common/releases/tag/1.2.7

Fixes;
Serialisation is based on the value of the `iss` field of the software
statement, and the code expected OpenBanking iss to be "OpenBanking",
however in OB Directory Issued Software Statements the iss field is
actually "OpenBanking Ltd"

Issue: https://github.com/ForgeCloud/ob-deploy/issues/793