### PR TITLE
793: Fix more issues with DirectorySoftwareStatement serialisation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,8 +44,8 @@
     <url>http://www.forgerock.org</url>
 
     <properties>
-        <ob-common.version>1.2.8</ob-common.version>
-        <ob-clients.version>1.2.8</ob-clients.version>
+        <ob-common.version>1.2.9</ob-common.version>
+        <ob-clients.version>1.2.9</ob-clients.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
Use latest commons with fix to ensure `iss` field is visible in DirectorySoftwareStatement serialisation.
Also includes fix to add iss field to SoftwareStatement issued by the Directory Server.

Includes https://github.com/OpenBankingToolkit/openbanking-common/pull/140