### PR TITLE
Create release 1.2.8

### DIFF
--- a/forgerock-openbanking-jwkms-core/pom.xml
+++ b/forgerock-openbanking-jwkms-core/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.jwkms</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-        <version>1.2.8-SNAPSHOT</version>
+        <version>1.2.8</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-core/pom.xml
+++ b/forgerock-openbanking-jwkms-core/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.jwkms</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-        <version>1.2.8</version>
+        <version>1.2.9-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-embedded/pom.xml
+++ b/forgerock-openbanking-jwkms-embedded/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.jwkms</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-        <version>1.2.8-SNAPSHOT</version>
+        <version>1.2.8</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-embedded/pom.xml
+++ b/forgerock-openbanking-jwkms-embedded/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.jwkms</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-        <version>1.2.8</version>
+        <version>1.2.9-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-sample/pom.xml
+++ b/forgerock-openbanking-jwkms-sample/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.jwkms</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-        <version>1.2.8-SNAPSHOT</version>
+        <version>1.2.8</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-sample/pom.xml
+++ b/forgerock-openbanking-jwkms-sample/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.jwkms</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-        <version>1.2.8</version>
+        <version>1.2.9-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-server/pom.xml
+++ b/forgerock-openbanking-jwkms-server/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.jwkms</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-        <version>1.2.8-SNAPSHOT</version>
+        <version>1.2.8</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-server/pom.xml
+++ b/forgerock-openbanking-jwkms-server/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.jwkms</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-        <version>1.2.8</version>
+        <version>1.2.9-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - JWKMS</name>
     <groupId>com.forgerock.openbanking.jwkms</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-    <version>1.2.8</version>
+    <version>1.2.9-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -117,7 +117,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-jwkms.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-jwkms.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-jwkms.git</url>
-      <tag>1.2.8</tag>
+      <tag>HEAD</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - JWKMS</name>
     <groupId>com.forgerock.openbanking.jwkms</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-    <version>1.2.8-SNAPSHOT</version>
+    <version>1.2.8</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -117,7 +117,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-jwkms.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-jwkms.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-jwkms.git</url>
-      <tag>HEAD</tag>
+      <tag>1.2.8</tag>
   </scm>
 
   <distributionManagement>


### PR DESCRIPTION
793: Fix more issues with DirectorySoftwareStatement serialisation

Use latest commons with fix to ensure `iss` field is visible in DirectorySoftwareStatement serialisation.
Also includes fix to add iss field to SoftwareStatement issued by the Directory Server.

Includes https://github.com/OpenBankingToolkit/openbanking-common/pull/140