### PR TITLE
Release 1.2.11 and use latest parent and commons

### DIFF
--- a/forgerock-openbanking-jwkms-core/pom.xml
+++ b/forgerock-openbanking-jwkms-core/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.jwkms</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-        <version>1.2.11</version>
+        <version>1.2.12-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-embedded/pom.xml
+++ b/forgerock-openbanking-jwkms-embedded/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.jwkms</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-        <version>1.2.11</version>
+        <version>1.2.12-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-sample/pom.xml
+++ b/forgerock-openbanking-jwkms-sample/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.jwkms</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-        <version>1.2.11</version>
+        <version>1.2.12-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-server/pom.xml
+++ b/forgerock-openbanking-jwkms-server/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.jwkms</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-        <version>1.2.11</version>
+        <version>1.2.12-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - JWKMS</name>
     <groupId>com.forgerock.openbanking.jwkms</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-    <version>1.2.11</version>
+    <version>1.2.12-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -117,7 +117,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-jwkms.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-jwkms.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-jwkms.git</url>
-      <tag>1.2.11</tag>
+      <tag>HEAD</tag>
   </scm>
 
   <distributionManagement>


### PR DESCRIPTION
Allow creation of OBRIRoles from PSD2Role
Also;
Pulls in 1.0.3 of spring-security-mult-auth that has improved logging
Issue: https://github.com/ForgeCloud/ob-deploy/issues/802