### PR TITLE
45: Release 1.2.13 to use latest uk datamodels

### DIFF
--- a/forgerock-openbanking-jwkms-core/pom.xml
+++ b/forgerock-openbanking-jwkms-core/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.jwkms</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-        <version>1.2.13-SNAPSHOT</version>
+        <version>1.2.13</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-core/pom.xml
+++ b/forgerock-openbanking-jwkms-core/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.jwkms</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-        <version>1.2.13</version>
+        <version>1.2.14-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-embedded/pom.xml
+++ b/forgerock-openbanking-jwkms-embedded/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.jwkms</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-        <version>1.2.13-SNAPSHOT</version>
+        <version>1.2.13</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-embedded/pom.xml
+++ b/forgerock-openbanking-jwkms-embedded/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.jwkms</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-        <version>1.2.13</version>
+        <version>1.2.14-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-sample/pom.xml
+++ b/forgerock-openbanking-jwkms-sample/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.jwkms</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-        <version>1.2.13-SNAPSHOT</version>
+        <version>1.2.13</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-sample/pom.xml
+++ b/forgerock-openbanking-jwkms-sample/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.jwkms</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-        <version>1.2.13</version>
+        <version>1.2.14-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-server/pom.xml
+++ b/forgerock-openbanking-jwkms-server/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.jwkms</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-        <version>1.2.13-SNAPSHOT</version>
+        <version>1.2.13</version>
     </parent>
 
     <dependencies>

--- a/forgerock-openbanking-jwkms-server/pom.xml
+++ b/forgerock-openbanking-jwkms-server/pom.xml
@@ -30,7 +30,7 @@
     <parent>
         <groupId>com.forgerock.openbanking.jwkms</groupId>
         <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-        <version>1.2.13</version>
+        <version>1.2.14-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-parent</artifactId>
-        <version>1.2.5</version>
+        <version>1.2.6</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 
@@ -44,8 +44,8 @@
     <url>http://www.forgerock.org</url>
 
     <properties>
-        <ob-common.version>1.2.13</ob-common.version>
-        <ob-clients.version>1.2.13</ob-clients.version>
+        <ob-common.version>1.2.14</ob-common.version>
+        <ob-clients.version>1.2.14</ob-clients.version>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - JWKMS</name>
     <groupId>com.forgerock.openbanking.jwkms</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-    <version>1.2.13-SNAPSHOT</version>
+    <version>1.2.13</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -117,7 +117,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-jwkms.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-jwkms.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-jwkms.git</url>
-      <tag>HEAD</tag>
+      <tag>1.2.13</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <name>ForgeRock OpenBanking Reference Implementation - JWKMS</name>
     <groupId>com.forgerock.openbanking.jwkms</groupId>
     <artifactId>forgerock-openbanking-reference-implementation-jwkms</artifactId>
-    <version>1.2.13</version>
+    <version>1.2.14-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
@@ -117,7 +117,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-jwkms.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-jwkms.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-jwkms.git</url>
-      <tag>1.2.13</tag>
+      <tag>HEAD</tag>
   </scm>
 
   <distributionManagement>


### PR DESCRIPTION
45: Use fixed uk-datamodel for 3.1.8

OBFundsConfirmationConsentResponse1Data uses OBExternalRequestStatus1Code rather than the StatusEnum
defined within the class.

Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/45